### PR TITLE
Automatic service installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ run `autotrash --install` to create a systemd service which runs daily with the 
 
 will run `/usr/bin/autotrash -d 30` daily.
 
-The service can be manually started with `systemctl start autotrash`.
-The timer can be enabled and disabled using `systemctl enable autotrash.timer` and
-`systemctl disable autotrash.timer` respectively.
+The service can be manually started with `systemctl --user start autotrash`.
+The timer can be enabled and disabled using `systemctl --user enable autotrash.timer` and
+`systemctl --user disable autotrash.timer` respectively.
 
-Only one autotrash service can exist on the machine and root access is required during installation so this option may not be appropriate for all use cases.
+The service is installed to `~/.config/systemd/user` so like the cron approach, root access is not required and multiple users have their own independent services.
 
 
 ## Manual Cron Setup ##

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ trash information file.
 ![Travis CI build status](https://api.travis-ci.org/bneijt/autotrash.svg)
 
 Installation
-------------
+============
 
 On Fedora consider using `yum install autotrash`
 
@@ -20,8 +20,24 @@ Last option is to install autotrash using pip, for example, using: `pip install 
 
 
 Configuration
--------------
-It should be considered to be run as a crontab entry:
+=============
+
+## Automatic Setup ##
+run `autotrash --install` to create a systemd service which runs daily with the provided arguments. For example
+
+    autotrash -d 30 --install
+
+will run `/usr/bin/autotrash -d 30` daily.
+
+The service can be manually started with `systemctl start autotrash`.
+The timer can be enabled and disabled using `systemctl enable autotrash.timer` and
+`systemctl disable autotrash.timer` respectively.
+
+Only one autotrash service can exist on the machine and root access is required during installation so this option may not be appropriate for all use cases.
+
+
+## Manual Cron Setup ##
+To run autotrash daily using cron, add the following crontab entry:
 
     @daily /usr/bin/autotrash -d 30
 
@@ -36,12 +52,18 @@ Or more frequently, but to keep disk IO down, only when there is less then 3GB o
 To configure this, run "crontab -e" and add one of these lines in the
 editor, then save and close the file.
 
+
+## System Startup Setup ##
 If you do not know how to work with crontab, you could add it to the startup
 programs in GNOME using the menu: System -> Preferences -> Sessions
 
 Add the program with the "+ Add" button.
 
 This will make sure that your trash is cleaned up every time you log in.
+
+
+Information
+===========
 
 Homepage: https://github.com/bneijt/autotrash
 
@@ -51,6 +73,7 @@ Epel7 package is still in the testing repo but should go stable within few days.
 You can install the package on Fedora right now with:
 
     yum install autotrash
+
 
 Development
 ===========

--- a/src/autotrash/app.py
+++ b/src/autotrash/app.py
@@ -362,14 +362,14 @@ Persistent=true
 WantedBy=timers.target
 '''
 
-    service_file = f'''\
+    service_file = '''\
 [Unit]
 Description=Empty trash
 
 [Service]
 Type=oneshot
-ExecStart="{executable_path}" {args}
-'''
+ExecStart="{}" {}
+'''.format(executable_path, args)
 
     systemd_dir = os.path.expanduser('~/.config/systemd/user')
     os.makedirs(systemd_dir, exist_ok=True)
@@ -380,7 +380,7 @@ ExecStart="{executable_path}" {args}
     with open(os.path.join(systemd_dir, 'autotrash.service'), 'w') as f:
         f.write(service_file)
 
-    logging.info(f'service installed to "{systemd_dir}"')
+    logging.info('service installed to "{}"'.format(systemd_dir))
     subprocess.check_output(['systemctl', '--user', 'enable', 'autotrash.timer'])
     logging.info('checking that the service is working...')
     subprocess.check_output(['systemctl', '--user', 'start', 'autotrash'])

--- a/src/autotrash/app.py
+++ b/src/autotrash/app.py
@@ -27,6 +27,7 @@ import sys
 import datetime
 import tempfile
 import subprocess
+import getpass
 from typing import Union
 
 import math
@@ -350,8 +351,6 @@ def install_service(options, args):
         logging.error('autotrash not found in the path')
 
     args = subprocess.list2cmdline([arg for arg in sys.argv[1:] if arg != '--install'])
-    # overriding XDG_DATA_HOME because root may not have a trash information directory
-    xdg_data_home = os.getenv('XDG_DATA_HOME', os.path.expanduser('~/.local/share'))
 
     timer_file = '''\
 [Unit]
@@ -371,7 +370,7 @@ Description=Empty trash
 
 [Service]
 Type=oneshot
-Environment="XDG_DATA_HOME={xdg_data_home}"
+User={getpass.getuser()}
 ExecStart="{executable_path}" {args}
 '''
 

--- a/src/autotrash/app.py
+++ b/src/autotrash/app.py
@@ -374,7 +374,6 @@ ExecStart="{executable_path}" {args}
     systemd_dir = os.path.expanduser('~/.config/systemd/user')
     os.makedirs(systemd_dir, exist_ok=True)
 
-
     with open(os.path.join(systemd_dir, 'autotrash.timer'), 'w') as f:
         f.write(timer_file)
 
@@ -382,7 +381,6 @@ ExecStart="{executable_path}" {args}
         f.write(service_file)
 
     logging.info(f'service installed to "{systemd_dir}"')
-
     subprocess.check_output(['systemctl', '--user', 'enable', 'autotrash.timer'])
     logging.info('checking that the service is working...')
     subprocess.check_output(['systemctl', '--user', 'start', 'autotrash'])
@@ -405,12 +403,11 @@ def main():
         )
         return 1
 
+    check_options(parser, options)
+
     if options.install:
         install_service(options, args)
         return 1
-
-
-    check_options(parser, options)
 
     # Compile list of possible trash directories
     trash_paths = find_trash_directories(options.trash_path, options.trash_mounts)

--- a/src/autotrash/options.py
+++ b/src/autotrash/options.py
@@ -93,6 +93,11 @@ def new_parser() -> optparse.OptionParser:
         action='store_true', dest='version',
         help='show version and exit'
     )
+    parser.add_option(
+        '--install',
+        action='store_true', dest='install',
+        help='set autotrash to run automatically with the given options'
+    )
     return parser
 
 


### PR DESCRIPTION
adds an `--install` option which creates a systemd service which runs autotrash periodically.

for example `autotrash --days 1 --install` will copy the `--days 1` arguments to the service and will use that option each time the service runs.

originally I installed the service to `/etc/systemd/system` but I realised that it is better for each user to have their own autotrash service and like cron, installation shouldn't require root access. So now I'm installing to `~/.config/systemd/user`.

I don't know whether it makes sense to install a service to run automatically during installation of the autotrash package, but this approach could be used to do so.

systemd timers also support other intervals like `hourly` but I wasn't sure how best to give options like that to the user so I kept it simple and hard coded a daily run. The resulting unit files can be manually edited by the user of course.