### PR TITLE
Add .gnomerc Example For Granular Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ Add the program with the "+ Add" button.
 
 This will make sure that your trash is cleaned up every time you log in.
 
+## ~/.gnomerc ##
+
+You can create a script thats run at login to Gnome: `~/.gnomerc`. One advantage to this method is ability to have different rules for various trash folders. For example:
+```
+#!/bin/bash
+# Empty homedir trash
+autotrash --days 30 --trash-path=~/.local/share/Trash
+# Empty trash for non-home folders:
+autotrash --days 10 --trash-path=/dpool/vcmain/.Trash-`id -u`
+autotrash --days 15 --trash-path=/dpool/vccorp/.Trash-`id -u`
+```
 
 General information
 ===========


### PR DESCRIPTION
In my case, I need different settings as I have frequent ZFS snapshots on some datasets and don't need long trash holds there. Also, there is a [known issue](https://gitlab.gnome.org/GNOME/gvfs/-/issues/622#note_1439433) with GVFS, Trash and snapshots.

Thanks for the tool!