### PR TITLE
doc: mention nixpkgs python3Packages.autotrash

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Using a distribution package is preferred as it will also ensure that autotrash 
         ```
     - On ArchLinux, there is an [AUR package available](https://aur.archlinux.org/packages/autotrash/)
 
+    - On NixOS (or any system with `nix`), there is the `python3Packages.autotrash` package in nixpkgs-unstable
+
 Finally you could try using `pip` directly if `pipx` is not available.
 
 Configuration


### PR DESCRIPTION
NixOS users or fans of the nix package manager may prefer to use this over pip(x). I'll try to remember to update this to not mention -unstable when the next release of NixOS is out (I think it should be in November).