### PR TITLE
doc: update nixpkgs reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Using a distribution package is preferred as it will also ensure that autotrash 
         ```
     - On ArchLinux, there is an [AUR package available](https://aur.archlinux.org/packages/autotrash/)
 
-    - On NixOS (or any system with `nix`), there is the `python3Packages.autotrash` package in nixpkgs-unstable
+    - On NixOS (or any system with `nix`), there is the `autotrash` package
 
 Finally you could try using `pip` directly if `pipx` is not available.
 


### PR DESCRIPTION
The `autotrash` package has been moved out of `python3Packages` (though it is
still available there for backwards-compatibility), and is also available in the
stable release.
